### PR TITLE
move create_null_object_cb from server.cpp to service_client_api.hpp,…

### DIFF
--- a/include/cascade/service_client_api.hpp
+++ b/include/cascade/service_client_api.hpp
@@ -349,5 +349,16 @@ CascadeObjpoolLinq<CascadeType,ServiceClientType> from_objectpool(
 
 #endif//HAS_BOOLINQ
 
+// specialize create_null_object_cb for Cascade Types...
+using opm_t = ObjectPoolMetadata<VolatileCascadeStoreWithStringKey,PersistentCascadeStoreWithStringKey,TriggerCascadeNoStoreWithStringKey>;
+template<>
+inline opm_t create_null_object_cb<std::string,opm_t,&opm_t::IK,&opm_t::IV>(const std::string& key) {
+    opm_t opm;
+    opm.pathname = key;
+    opm.subgroup_type_index = opm_t::invalid_subgroup_type_index;
+    return opm;
+}
+
+
 }// namespace cascade
 }// namespace derecho

--- a/src/service/server.cpp
+++ b/src/service/server.cpp
@@ -1,6 +1,11 @@
 #include <cascade/cascade.hpp>
 #include <cascade/service.hpp>
 #include <cascade/service_types.hpp>
+// 
+// We should add a cascade service library side-by-side to libcascade.so to include the client-side implementations for
+// cascade service client. Right now, we put some of the implementations (create_null_object_cb<>, e.g.) as inline
+// functions in service_client_api.hpp. It's not a good design, which should change later.
+#include <cascade/service_client_api.hpp>
 #include <cascade/object.hpp>
 #include <sys/prctl.h>
 #include <derecho/conf/conf.hpp>
@@ -116,6 +121,9 @@ class CascadeServiceCDPO: public CriticalDataPathObserver<CascadeType> {
     }
 };
 
+/**
+ * This part has moved to service_client_api.hpp
+ *
 namespace derecho::cascade {
 // specialize create_null_object_cb for Cascade Types...
 using opm_t = ObjectPoolMetadata<VolatileCascadeStoreWithStringKey,PersistentCascadeStoreWithStringKey,TriggerCascadeNoStoreWithStringKey>;
@@ -127,6 +135,7 @@ opm_t create_null_object_cb<std::string,opm_t,&opm_t::IK,&opm_t::IV>(const std::
     return opm;
 }
 }
+**/
 
 int main(int argc, char** argv) {
     // set proc name


### PR DESCRIPTION
… so that client side can also see it.

We should add a cascade service library side-by-side to libcascade.so to include the client-side implementations.